### PR TITLE
Implement heuristics for disabling resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,17 @@ an mDNS responder. (Don't try to use the tools `host` or
 If you run a firewall, don't forget to allow UDP traffic to the the
 mDNS multicast address `224.0.0.251` on port 5353.
 
-**Please note:** The line above makes `nss-mdns`
-authoritative for the `.local` domain. If you have a unicast
-DNS domain with the same name you will no longer be able to resolve
-hosts from it. mDNS and a unicast DNS domain named `.local` are
-inherently incompatible. Please contact your local admistrator and ask
-him to move to a different domain name since `.local` is to be
-used exclusively for Zeroconf technology. [Further
-information](http://avahi.org/wiki/AvahiAndUnicastDotLocal).
+**Please note:** The line above makes `nss-mdns` authoritative for the
+`.local` domain, unless your unicast DNS server responds to `SOA`
+queries for the top level `local` name, or if the request has more
+than two labels. (`X.local` might be resolved with `nss-mdns` but
+`X.Y.local` will not be.) `nss-mdns` will check `SOA` before every
+request to resolve `.local` names, meaning that neither `nss-mdns` nor
+`Avahi` need to be disabled to allow `.local` queries to be served
+from unicast DNS. (These two checks are only enabled in minimal mode
+or if there is no `/etc/mdns.allow` file. Any domain, with any number
+of labels, (including `.local`) will still be served authoritatively
+from `nss-mdns` if specified in `/etc/mdns.allow`.)
 
 Starting with version 0.5, `nss-mdns` has a simple
 configuration file `/etc/mdns.allow` for enabling name lookups
@@ -149,7 +152,7 @@ only (similar to `nss-mdns` mode of operation of versions &lt;= 0.4):
 ```
 
 If the configuration file is absent or unreadable
-`nss-mdns` behaves as if a configuration file with the following
+`nss-mdns` behaves mostly as if a configuration file with the following
 contents is read:
 
 ```
@@ -158,8 +161,11 @@ contents is read:
 .local
 ```
 
-i.e. only hostnames ending with `.local` are resolved via
-mDNS.
+i.e. only hostnames ending with `.local` are resolved via mDNS. Note
+that this is not exactly the same as having no such file, since we will
+always be authoritative for the entries in the file. (The heuristics
+of checking for SOA and requiring two-label names do not apply if the
+configuration file is used.)
 
 If the configuration file is existent but empty, mDNS name lookups are
 disabled completely. Please note that usually mDNS is not used for

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_HEADER_TIME
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_SELECT_ARGTYPES
+AC_SEARCH_LIBS([__res_nquery], [resolv])
 AC_CHECK_FUNCS([gethostbyaddr gethostbyname gettimeofday inet_ntoa memset select socket strcspn strdup strerror strncasecmp strcasecmp strspn])
 
 # FreeBSD has a slightly different NSS interface

--- a/src/nss.c
+++ b/src/nss.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "avahi.h"
+#include "util.h"
 
 #if defined(NSS_IPV4_ONLY) && ! defined(MDNS_MINIMAL)
 #define _nss_mdns_gethostbyname2_r _nss_mdns4_gethostbyname2_r
@@ -192,7 +193,7 @@ enum nss_status _nss_mdns_gethostbyname2_r(
 #ifndef MDNS_MINIMAL
     mdns_allow_file = fopen(MDNS_ALLOW_FILE, "r");
 #endif
-    name_allowed = verify_name_allowed(name, mdns_allow_file);
+    name_allowed = verify_name_allowed_with_soa(name, mdns_allow_file);
 #ifndef MDNS_MINIMAL
     if (mdns_allow_file)
         fclose(mdns_allow_file);

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -17,7 +17,7 @@
   USA.
 ***/
 
-#define _POSIX_C_SOURCE 200809L
+#define _DEFAULT_SOURCE
 
 #include <check.h>
 #include <stdlib.h>
@@ -26,17 +26,29 @@
 
 // Tests that verify_name_allowed works in MINIMAL mode, or with no config file.
 // Only names with TLD "local" are allowed.
+// Only 2-label names are allowed.
+// SOA check is required.
 START_TEST(test_verify_name_allowed_minimal) {
-    ck_assert(verify_name_allowed("example.local", NULL));
-    ck_assert(verify_name_allowed("example.local.", NULL));
-    ck_assert(verify_name_allowed("com.example.local", NULL));
-    ck_assert(verify_name_allowed("com.example.local.", NULL));
-    ck_assert(!verify_name_allowed("example.com", NULL));
-    ck_assert(!verify_name_allowed("example.com.", NULL));
-    ck_assert(!verify_name_allowed("example.local.com", NULL));
-    ck_assert(!verify_name_allowed("example.local.com.", NULL));
-    ck_assert(!verify_name_allowed("", NULL));
-    ck_assert(!verify_name_allowed(".", NULL));
+    ck_assert_int_eq(verify_name_allowed("example.local", NULL),
+                     VERIFY_NAME_RESULT_ALLOWED_IF_NO_LOCAL_SOA);
+    ck_assert_int_eq(verify_name_allowed("example.local.", NULL),
+                     VERIFY_NAME_RESULT_ALLOWED_IF_NO_LOCAL_SOA);
+    ck_assert_int_eq(verify_name_allowed("com.example.local", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("com.example.local.", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("example.com", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("example.com.", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("example.local.com", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("example.local.com.", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed("", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed(".", NULL),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
@@ -55,60 +67,115 @@ static int verify_name_allowed_from_string(const char *name,
 START_TEST(test_verify_name_allowed_empty) {
     const char allow_file[] = "";
 
-    ck_assert(!verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(!verify_name_allowed_from_string("com.example.local.",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com.",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("", allow_file));
-    ck_assert(!verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string(".", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
 // Tests verify_name_allowed with the standard config.
+// .local is unconditionally permitted, without SOA check.
+// Multi-label names are allowed.
 START_TEST(test_verify_name_allowed_default) {
     const char allow_file[] =
         "# /etc/mdns.allow\n"
         ".local.\n"
         ".local\n";
 
-    ck_assert(verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com.",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("", allow_file));
-    ck_assert(!verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
 // Tests verify_name_allowed with wildcard.
+// Everything is permitted, with no SOA check.
+// Multi-label names are allowed.
 START_TEST(test_verify_name_allowed_wildcard) {
     const char allow_file[] = "*\n";
 
-    ck_assert(verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.com",
-                                              allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.com.",
-                                              allow_file));
-    ck_assert(verify_name_allowed_from_string("", allow_file));
-    ck_assert(verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string(".", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
 }
 END_TEST
 
@@ -123,18 +190,32 @@ START_TEST(test_verify_name_allowed_too_long) {
         "\n"
         ".local\n";
 
-    ck_assert(verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com.",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("", allow_file));
-    ck_assert(!verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com.", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
@@ -152,36 +233,52 @@ START_TEST(test_verify_name_allowed_too_long2) {
         ".local\n";
 
     // The input is truncated at 127 bytes, so we allow this string.
-    ck_assert(verify_name_allowed_from_string(
+    ck_assert_int_eq(verify_name_allowed_from_string(
         "example"
         ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaa",                       // 27 characters
-        allow_file));
+        allow_file),
+                     VERIFY_NAME_RESULT_ALLOWED);
 
     // Even though this exactly matches the item in the allow file,
     // it is too long.
-    ck_assert(!verify_name_allowed_from_string(
+    ck_assert_int_eq(verify_name_allowed_from_string(
         "example"
         ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 50 characters
-        allow_file));
+        allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 
-    ck_assert(verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("example.local.com.",
-                                               allow_file));
-    ck_assert(!verify_name_allowed_from_string("", allow_file));
-    ck_assert(!verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com.", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
@@ -194,18 +291,38 @@ START_TEST(test_verify_name_allowed_com_and_local) {
         ".local.\n"
         ".local\n";
 
-    ck_assert(verify_name_allowed_from_string("example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local", allow_file));
-    ck_assert(verify_name_allowed_from_string("com.example.local.", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.com", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.com.", allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.com",
-                                              allow_file));
-    ck_assert(verify_name_allowed_from_string("example.local.com.",
-                                              allow_file));
-    ck_assert(!verify_name_allowed_from_string("", allow_file));
-    ck_assert(!verify_name_allowed_from_string(".", allow_file));
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("com.example.local.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.local.com.", allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.net", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.net.", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
@@ -221,6 +338,21 @@ START_TEST(test_ends_with) {
     ck_assert(ends_with("example.local.", ".local."));
     ck_assert(!ends_with("example.local.", ".local"));
     ck_assert(!ends_with("example.local.", ".local"));
+}
+END_TEST
+
+// Tests label_count.
+START_TEST(test_label_count) {
+  ck_assert_int_eq(label_count(""), 1);
+  ck_assert_int_eq(label_count("."), 1);
+  ck_assert_int_eq(label_count("local"), 1);
+  ck_assert_int_eq(label_count("local."), 1);
+  ck_assert_int_eq(label_count("foo.local"), 2);
+  ck_assert_int_eq(label_count("foo.local."), 2);
+  ck_assert_int_eq(label_count("bar.foo.local"), 3);
+  ck_assert_int_eq(label_count("bar.foo.local."), 3);
+  ck_assert_int_eq(label_count("my-foo.local"), 2);
+  ck_assert_int_eq(label_count("my-foo.local."), 2);
 }
 END_TEST
 
@@ -240,6 +372,7 @@ static Suite *util_suite(void) {
     tcase_add_test(tc_core, test_verify_name_allowed_too_long2);
     tcase_add_test(tc_core, test_verify_name_allowed_com_and_local);
     tcase_add_test(tc_core, test_ends_with);
+    tcase_add_test(tc_core, test_label_count);
     suite_add_tcase(s, tc_core);
 
     return s;


### PR DESCRIPTION
If a DNS operator has records for "local" they probably don't want
mDNS to override them. The standard way to tell this is by doing an SOA
lookup for "local" and refusing to do an mDNS lookup if unicast DNS
claims authority.

This change allows avahi to always run and perform service discovery
while continuing to allow unicast DNS servers to return A and AAAA
records for "local" names.

Problematic boot time detection is no longer required, and since SOA
resolution is done as needed, clients will dynamically react to
configuration updates of unicast "local" resolution.

This also disables mDNS resolution for "local" names that have more than
2 labels. This helps ensure that unicast DNS is used when local network
administrators intend it.

See Apple's description of their implementation of this functionality:
https://support.apple.com/en-us/HT201275

These heuristics are only enabled in minimal mode, or if there is no
/etc/mdns.allow file. A valid /etc/mdns.allow file will override
these two checks.
