### PR TITLE
Make the dependency on check optional (needed for tests only)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,13 @@ ac_default_prefix="/"
 
 AC_GNU_SOURCE
 
-PKG_CHECK_MODULES([CHECK], [check])
+PKG_CHECK_MODULES([CHECK], [check], [have_check=yes], [have_check=no])
+AM_CONDITIONAL([HAVE_CHECK], [test "x$have_check" = "xyes"])
+
+if test "x$have_check" = "xno" ; then
+    AC_MSG_WARN([$CHECK_PKG_ERRORS])
+    AC_MSG_WARN([Unit tests will be disabled])
+fi
 
 # Checks for programs.
 AC_PROG_CC

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,11 @@
+if HAVE_CHECK
+
 TESTS = check_util
 check_PROGRAMS = check_util
 check_util_SOURCES = check_util.c $(top_builddir)/src/util.h
 check_util_CFLAGS = @CHECK_CFLAGS@
 check_util_LDADD = $(top_builddir)/src/util.o @CHECK_LIBS@
+
+endif
+
+EXTRA_DIST = check_util.c


### PR DESCRIPTION
Make the pkg-config check on 'check' library non-fatal, disabling
the unit tests when the library is not available rather than causing
the package to refuse to compile. Many of the users are not even running
tests, so there is no reason to force them to install the dependency.