### PR TITLE
Reformat to 80 cols

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
-ColumnLimit: 0
 PointerAlignment: Left
 SortIncludes: false

--- a/src/avahi-test.c
+++ b/src/avahi-test.c
@@ -27,18 +27,23 @@ int main(int argc, char* argv[]) {
     char t[256];
     int r;
 
-    if ((r = avahi_resolve_name(AF_INET, argc >= 2 ? argv[1] : "cocaine.local", &result)) == 0)
-        printf("AF_INET: %s\n", inet_ntop(AF_INET, &(result.address.ipv4), t, sizeof(t)));
+    if ((r = avahi_resolve_name(AF_INET, argc >= 2 ? argv[1] : "cocaine.local",
+                                &result)) == 0)
+        printf("AF_INET: %s\n",
+               inet_ntop(AF_INET, &(result.address.ipv4), t, sizeof(t)));
     else
         printf("AF_INET: failed (%i).\n", r);
 
-    if ((r = avahi_resolve_address(AF_INET, &(result.address.ipv4), t, sizeof(t))) == 0)
+    if ((r = avahi_resolve_address(AF_INET, &(result.address.ipv4), t,
+                                   sizeof(t))) == 0)
         printf("REVERSE: %s\n", t);
     else
         printf("REVERSE: failed (%i).\n", r);
 
-    if ((r = avahi_resolve_name(AF_INET6, argc >= 2 ? argv[1] : "cocaine.local", &result)) == 0)
-        printf("AF_INET6: %s\n", inet_ntop(AF_INET6, &(result.address.ipv6), t, sizeof(t)));
+    if ((r = avahi_resolve_name(AF_INET6, argc >= 2 ? argv[1] : "cocaine.local",
+                                &result)) == 0)
+        printf("AF_INET6: %s\n",
+               inet_ntop(AF_INET6, &(result.address.ipv6), t, sizeof(t)));
     else
         printf("AF_INET6: failed (%i).\n", r);
 

--- a/src/avahi.c
+++ b/src/avahi.c
@@ -65,13 +65,14 @@ fail:
     return NULL;
 }
 
-static avahi_resolve_result_t avahi_resolve_name_with_socket(FILE* f, int af,
-                                                             const char* name,
-                                                             query_address_result_t* result) {
+static avahi_resolve_result_t
+avahi_resolve_name_with_socket(FILE* f, int af, const char* name,
+                               query_address_result_t* result) {
     char* p;
     char ln[256];
 
-    fprintf(f, "RESOLVE-HOSTNAME%s %s\n", af == AF_INET ? "-IPV4" : "-IPV6", name);
+    fprintf(f, "RESOLVE-HOSTNAME%s %s\n", af == AF_INET ? "-IPV4" : "-IPV6",
+            name);
     fflush(f);
 
     if (!(fgets(ln, sizeof(ln), f))) {
@@ -121,17 +122,15 @@ avahi_resolve_result_t avahi_resolve_name(int af, const char* name,
         return AVAHI_RESOLVE_RESULT_UNAVAIL;
     }
 
-    avahi_resolve_result_t ret = avahi_resolve_name_with_socket(f, af, name,
-                                                                result);
+    avahi_resolve_result_t ret =
+        avahi_resolve_name_with_socket(f, af, name, result);
     fclose(f);
     return ret;
 }
 
-static avahi_resolve_result_t avahi_resolve_address_with_socket(FILE* f,
-                                                                int af,
-                                                                const void* data,
-                                                                char* name,
-                                                                size_t name_len) {
+static avahi_resolve_result_t
+avahi_resolve_address_with_socket(FILE* f, int af, const void* data, char* name,
+                                  size_t name_len) {
     char* p;
     char a[256], ln[256];
 

--- a/src/map-file
+++ b/src/map-file
@@ -8,17 +8,17 @@ _nss_mdns_minimal_gethostbyaddr_r;
 _nss_mdns4_minimal_gethostbyaddr_r;
 _nss_mdns6_minimal_gethostbyaddr_r;
 
-_nss_mdns_gethostbyname_r;         
+_nss_mdns_gethostbyname_r;
 _nss_mdns4_gethostbyname_r;
 _nss_mdns6_gethostbyname_r;
-_nss_mdns_minimal_gethostbyname_r;         
+_nss_mdns_minimal_gethostbyname_r;
 _nss_mdns4_minimal_gethostbyname_r;
 _nss_mdns6_minimal_gethostbyname_r;
 
-_nss_mdns_gethostbyname2_r;         
+_nss_mdns_gethostbyname2_r;
 _nss_mdns4_gethostbyname2_r;
 _nss_mdns6_gethostbyname2_r;
-_nss_mdns_minimal_gethostbyname2_r;         
+_nss_mdns_minimal_gethostbyname2_r;
 _nss_mdns4_minimal_gethostbyname2_r;
 _nss_mdns6_minimal_gethostbyname2_r;
 
@@ -36,6 +36,6 @@ _nss_mdns_minimal_gethostbyname4_r;
 _nss_mdns4_minimal_gethostbyname4_r;
 _nss_mdns6_minimal_gethostbyname4_r;
 
-local: 
+local:
 *;
 };

--- a/src/nss-test.c
+++ b/src/nss-test.c
@@ -53,16 +53,21 @@ static int gai(const char* node) {
         }
         switch (rp->ai_family) {
         case AF_INET:
-            inet_ntop(AF_INET, &((struct sockaddr_in*)rp->ai_addr)->sin_addr, str, sizeof(str));
-            fprintf(stderr, "[%d] addr type: inet\n[%d] address: %s\n", i, i, str);
+            inet_ntop(AF_INET, &((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+                      str, sizeof(str));
+            fprintf(stderr, "[%d] addr type: inet\n[%d] address: %s\n", i, i,
+                    str);
             break;
         case AF_INET6:
-            inet_ntop(AF_INET6, &((struct sockaddr_in6*)rp->ai_addr)->sin6_addr, str6, sizeof(str6));
+            inet_ntop(AF_INET6, &((struct sockaddr_in6*)rp->ai_addr)->sin6_addr,
+                      str6, sizeof(str6));
             int scope_id = ((struct sockaddr_in6*)rp->ai_addr)->sin6_scope_id;
             if (scope_id) {
-                fprintf(stderr, "[%d] addr type: inet6\n[%d] address: %s%%%d\n", i, i, str6, scope_id);
+                fprintf(stderr, "[%d] addr type: inet6\n[%d] address: %s%%%d\n",
+                        i, i, str6, scope_id);
             } else {
-                fprintf(stderr, "[%d] addr type: inet6\n[%d] address: %s\n", i, i, str6);
+                fprintf(stderr, "[%d] addr type: inet6\n[%d] address: %s\n", i,
+                        i, str6);
             }
             break;
         }
@@ -107,7 +112,10 @@ static int gethostbyX(const char* node) {
         fprintf(stderr, "\n");
     }
 
-    fprintf(stderr, "addr type: %s\n", he->h_addrtype == AF_INET ? "inet" : (he->h_addrtype == AF_INET6 ? "inet6" : NULL));
+    fprintf(stderr, "addr type: %s\n",
+            he->h_addrtype == AF_INET
+                ? "inet"
+                : (he->h_addrtype == AF_INET6 ? "inet6" : NULL));
     fprintf(stderr, "addr length: %i\n", he->h_length);
 
     fprintf(stderr, "addresses:");
@@ -122,7 +130,8 @@ static int gethostbyX(const char* node) {
 
 int main(int argc, char* argv[]) {
     if (argc != 2) {
-        fprintf(stderr, "Requires 1 argument: either a host or numeric address\n");
+        fprintf(stderr,
+                "Requires 1 argument: either a host or numeric address\n");
         return 1;
     }
     const char* node = argv[1];

--- a/src/nss.c
+++ b/src/nss.c
@@ -67,11 +67,18 @@
 #endif
 
 // Define prototypes for nss function we're going to export (fixes GCC warnings)
-enum nss_status _nss_mdns_gethostbyname4_r(const char*, struct gaih_addrtuple**, char*, size_t, int*, int*, int32_t*);
-enum nss_status _nss_mdns_gethostbyname3_r(const char*, int, struct hostent*, char*, size_t, int*, int*, int32_t*, char**);
-enum nss_status _nss_mdns_gethostbyname2_r(const char*, int, struct hostent*, char*, size_t, int*, int*);
-enum nss_status _nss_mdns_gethostbyname_r(const char*, struct hostent*, char*, size_t, int*, int*);
-enum nss_status _nss_mdns_gethostbyaddr_r(const void*, int, int, struct hostent*, char*, size_t, int*, int*);
+enum nss_status _nss_mdns_gethostbyname4_r(const char*, struct gaih_addrtuple**,
+                                           char*, size_t, int*, int*, int32_t*);
+enum nss_status _nss_mdns_gethostbyname3_r(const char*, int, struct hostent*,
+                                           char*, size_t, int*, int*, int32_t*,
+                                           char**);
+enum nss_status _nss_mdns_gethostbyname2_r(const char*, int, struct hostent*,
+                                           char*, size_t, int*, int*);
+enum nss_status _nss_mdns_gethostbyname_r(const char*, struct hostent*, char*,
+                                          size_t, int*, int*);
+enum nss_status _nss_mdns_gethostbyaddr_r(const void*, int, int,
+                                          struct hostent*, char*, size_t, int*,
+                                          int*);
 
 static avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
                                                     userdata_t* userdata) {
@@ -119,11 +126,9 @@ static avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
     }
 }
 
-static enum nss_status gethostbyname_impl(
-    const char* name, int af,
-    userdata_t* u,
-    int* errnop,
-    int* h_errnop) {
+static enum nss_status gethostbyname_impl(const char* name, int af,
+                                          userdata_t* u, int* errnop,
+                                          int* h_errnop) {
 
     int name_allowed;
     FILE* mdns_allow_file = NULL;
@@ -187,35 +192,31 @@ static enum nss_status gethostbyname_impl(
     }
 }
 
-enum nss_status _nss_mdns_gethostbyname4_r(
-    const char* name,
-    struct gaih_addrtuple** pat,
-    char* buffer, size_t buflen,
-    int* errnop, int* h_errnop,
-    int32_t* ttlp) {
+enum nss_status _nss_mdns_gethostbyname4_r(const char* name,
+                                           struct gaih_addrtuple** pat,
+                                           char* buffer, size_t buflen,
+                                           int* errnop, int* h_errnop,
+                                           int32_t* ttlp) {
 
     (void)ttlp;
 
     userdata_t u;
     buffer_t buf;
 
-    enum nss_status status = gethostbyname_impl(name, AF_UNSPEC, &u, errnop, h_errnop);
+    enum nss_status status =
+        gethostbyname_impl(name, AF_UNSPEC, &u, errnop, h_errnop);
     if (status != NSS_STATUS_SUCCESS) {
         return status;
     }
     buffer_init(&buf, buffer, buflen);
-    return convert_userdata_to_addrtuple(&u, name, pat, &buf,
-                                         errnop, h_errnop);
+    return convert_userdata_to_addrtuple(&u, name, pat, &buf, errnop, h_errnop);
 }
 
-enum nss_status _nss_mdns_gethostbyname3_r(
-    const char* name,
-    int af,
-    struct hostent* result,
-    char* buffer, size_t buflen,
-    int* errnop, int* h_errnop,
-    int32_t* ttlp,
-    char** canonp) {
+enum nss_status _nss_mdns_gethostbyname3_r(const char* name, int af,
+                                           struct hostent* result, char* buffer,
+                                           size_t buflen, int* errnop,
+                                           int* h_errnop, int32_t* ttlp,
+                                           char** canonp) {
 
     (void)ttlp;
     (void)canonp;
@@ -223,8 +224,8 @@ enum nss_status _nss_mdns_gethostbyname3_r(
     buffer_t buf;
     userdata_t u;
 
-    // The interfaces for gethostbyname3_r and below do not actually support returning results
-    // for more than one address family
+    // The interfaces for gethostbyname3_r and below do not actually support
+    // returning results for more than one address family
     if (af == AF_UNSPEC) {
 #ifdef NSS_IPV6_ONLY
         af = AF_INET6;
@@ -242,55 +243,35 @@ enum nss_status _nss_mdns_gethostbyname3_r(
                                                 errnop, h_errnop);
 }
 
-enum nss_status _nss_mdns_gethostbyname2_r(
-    const char* name,
-    int af,
-    struct hostent* result,
-    char* buffer, size_t buflen,
-    int* errnop, int* h_errnop) {
+enum nss_status _nss_mdns_gethostbyname2_r(const char* name, int af,
+                                           struct hostent* result, char* buffer,
+                                           size_t buflen, int* errnop,
+                                           int* h_errnop) {
 
-    return _nss_mdns_gethostbyname3_r(
-        name,
-        af,
-        result,
-        buffer, buflen,
-        errnop, h_errnop,
-        NULL, NULL);
+    return _nss_mdns_gethostbyname3_r(name, af, result, buffer, buflen, errnop,
+                                      h_errnop, NULL, NULL);
 }
 
-enum nss_status _nss_mdns_gethostbyname_r(
-    const char* name,
-    struct hostent* result,
-    char* buffer,
-    size_t buflen,
-    int* errnop,
-    int* h_errnop) {
+enum nss_status _nss_mdns_gethostbyname_r(const char* name,
+                                          struct hostent* result, char* buffer,
+                                          size_t buflen, int* errnop,
+                                          int* h_errnop) {
 
-    return _nss_mdns_gethostbyname2_r(
-        name,
-        AF_UNSPEC,
-        result,
-        buffer,
-        buflen,
-        errnop,
-        h_errnop);
+    return _nss_mdns_gethostbyname2_r(name, AF_UNSPEC, result, buffer, buflen,
+                                      errnop, h_errnop);
 }
 
-enum nss_status _nss_mdns_gethostbyaddr_r(
-    const void* addr,
-    int len,
-    int af,
-    struct hostent* result,
-    char* buffer,
-    size_t buflen,
-    int* errnop,
-    int* h_errnop) {
+enum nss_status _nss_mdns_gethostbyaddr_r(const void* addr, int len, int af,
+                                          struct hostent* result, char* buffer,
+                                          size_t buflen, int* errnop,
+                                          int* h_errnop) {
 
     size_t address_length;
     char t[256];
 
     /* Check for address types */
-    address_length = af == AF_INET ? sizeof(ipv4_address_t) : sizeof(ipv6_address_t);
+    address_length =
+        af == AF_INET ? sizeof(ipv4_address_t) : sizeof(ipv6_address_t);
 
     if (len < (int)address_length ||
 #ifdef NSS_IPV4_ONLY
@@ -308,8 +289,10 @@ enum nss_status _nss_mdns_gethostbyaddr_r(
 
 #ifdef MDNS_MINIMAL
     /* Only query for 169.254.0.0/16 IPv4 in minimal mode */
-    if ((af == AF_INET && ((ntohl(*(const uint32_t*)addr) & 0xFFFF0000UL) != 0xA9FE0000UL)) ||
-        (af == AF_INET6 && !(((const uint8_t*)addr)[0] == 0xFE && (((const uint8_t*)addr)[1] >> 6) == 2))) {
+    if ((af == AF_INET &&
+         ((ntohl(*(const uint32_t*)addr) & 0xFFFF0000UL) != 0xA9FE0000UL)) ||
+        (af == AF_INET6 && !(((const uint8_t*)addr)[0] == 0xFE &&
+                             (((const uint8_t*)addr)[1] >> 6) == 2))) {
         *errnop = EINVAL;
         *h_errnop = NO_RECOVERY;
         return NSS_STATUS_UNAVAIL;
@@ -321,9 +304,8 @@ enum nss_status _nss_mdns_gethostbyaddr_r(
     switch (avahi_resolve_address(af, addr, t, sizeof(t))) {
     case AVAHI_RESOLVE_RESULT_SUCCESS:
         buffer_init(&buf, buffer, buflen);
-        return convert_name_and_addr_to_hostent(t, addr, address_length,
-                                                af, result,
-                                                &buf, errnop, h_errnop);
+        return convert_name_and_addr_to_hostent(t, addr, address_length, af,
+                                                result, &buf, errnop, h_errnop);
 
     case AVAHI_RESOLVE_RESULT_HOST_NOT_FOUND:
         *errnop = ETIMEDOUT;

--- a/src/util.c
+++ b/src/util.c
@@ -122,8 +122,8 @@ int local_soa(void) {
     result = res_ninit(&state);
     if (result == -1)
         return 0;
-    result = res_nquery(&state, "local", ns_c_in, ns_t_soa,
-                        answer, sizeof answer);
+    result =
+        res_nquery(&state, "local", ns_c_in, ns_t_soa, answer, sizeof answer);
     res_nclose(&state);
     return result > 0;
 }
@@ -146,10 +146,9 @@ int label_count(const char* name) {
 
 enum nss_status convert_name_and_addr_to_hostent(const char* name,
                                                  const void* addr, int len,
-                                                 int af,
-                                                 struct hostent* result,
-                                                 buffer_t* buf,
-                                                 int* errnop, int* h_errnop) {
+                                                 int af, struct hostent* result,
+                                                 buffer_t* buf, int* errnop,
+                                                 int* h_errnop) {
     // Set empty list of aliases.
     result->h_aliases = (char**)buffer_alloc(buf, sizeof(char**));
     RETURN_IF_FAILED_ALLOC(result->h_aliases);
@@ -177,8 +176,8 @@ enum nss_status convert_name_and_addr_to_hostent(const char* name,
 enum nss_status convert_userdata_for_name_to_hostent(const userdata_t* u,
                                                      const char* name, int af,
                                                      struct hostent* result,
-                                                     buffer_t* buf,
-                                                     int* errnop, int* h_errnop) {
+                                                     buffer_t* buf, int* errnop,
+                                                     int* h_errnop) {
     size_t address_length =
         af == AF_INET ? sizeof(ipv4_address_t) : sizeof(ipv6_address_t);
 
@@ -212,8 +211,8 @@ enum nss_status convert_userdata_for_name_to_hostent(const userdata_t* u,
 enum nss_status convert_userdata_to_addrtuple(const userdata_t* u,
                                               const char* name,
                                               struct gaih_addrtuple** pat,
-                                              buffer_t* buf,
-                                              int* errnop, int* h_errnop) {
+                                              buffer_t* buf, int* errnop,
+                                              int* h_errnop) {
 
     // Copy name to buffer (referenced in every result address tuple).
     char* buffer_name = buffer_strdup(buf, name);
@@ -238,8 +237,8 @@ enum nss_status convert_userdata_to_addrtuple(const userdata_t* u,
             RETURN_IF_FAILED_ALLOC(tuple);
         }
 
-        size_t address_length =
-            result->af == AF_INET ? sizeof(ipv4_address_t) : sizeof(ipv6_address_t);
+        size_t address_length = result->af == AF_INET ? sizeof(ipv4_address_t)
+                                                      : sizeof(ipv6_address_t);
 
         // Assign the (always same) name.
         tuple->name = buffer_name;

--- a/src/util.h
+++ b/src/util.h
@@ -48,11 +48,11 @@ void* buffer_alloc(buffer_t* buf, size_t size);
 char* buffer_strdup(buffer_t* buf, const char* str);
 
 // Macro to help with checking buffer allocation results.
-#define RETURN_IF_FAILED_ALLOC(ptr) \
-    if (ptr == NULL) {              \
-        *errnop = ERANGE;           \
-        *h_errnop = NO_RECOVERY;    \
-        return NSS_STATUS_TRYAGAIN; \
+#define RETURN_IF_FAILED_ALLOC(ptr)                                            \
+    if (ptr == NULL) {                                                         \
+        *errnop = ERANGE;                                                      \
+        *h_errnop = NO_RECOVERY;                                               \
+        return NSS_STATUS_TRYAGAIN;                                            \
     }
 
 int set_cloexec(int fd);
@@ -91,26 +91,25 @@ int label_count(const char* name);
 // gethostbyaddr_r.
 enum nss_status convert_name_and_addr_to_hostent(const char* name,
                                                  const void* addr, int len,
-                                                 int af,
-                                                 struct hostent* result,
-                                                 buffer_t* buf,
-                                                 int* errnop, int* h_errnop);
+                                                 int af, struct hostent* result,
+                                                 buffer_t* buf, int* errnop,
+                                                 int* h_errnop);
 
 // Converts from the userdata struct into the hostent format, used by
 // gethostbyaddr3_r.
 enum nss_status convert_userdata_for_name_to_hostent(const userdata_t* u,
                                                      const char* name, int af,
                                                      struct hostent* result,
-                                                     buffer_t* buf,
-                                                     int* errnop, int* h_errnop);
+                                                     buffer_t* buf, int* errnop,
+                                                     int* h_errnop);
 
 // Converts from the userdata struct into the gaih_addrtuple format, used by
 // gethostbyaddr4_r.
 enum nss_status convert_userdata_to_addrtuple(const userdata_t* u,
                                               const char* name,
                                               struct gaih_addrtuple** pat,
-                                              buffer_t* buf,
-                                              int* errnop, int* h_errnop);
+                                              buffer_t* buf, int* errnop,
+                                              int* h_errnop);
 
 // Appends a query_address_result to userdata.
 void append_address_to_userdata(const query_address_result_t* result,

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -79,9 +79,8 @@ START_TEST(test_verify_name_allowed_empty) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("com.example.local.", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("example.com", allow_file),
-        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.com.", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
@@ -91,12 +90,10 @@ START_TEST(test_verify_name_allowed_empty) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local.com.", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("", allow_file),
-        VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string(".", allow_file),
-        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
 }
 END_TEST
 
@@ -104,10 +101,9 @@ END_TEST
 // .local is unconditionally permitted, without SOA check.
 // Multi-label names are allowed.
 START_TEST(test_verify_name_allowed_default) {
-    const char allow_file[] =
-        "# /etc/mdns.allow\n"
-        ".local.\n"
-        ".local\n";
+    const char allow_file[] = "# /etc/mdns.allow\n"
+                              ".local.\n"
+                              ".local\n";
 
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local", allow_file),
@@ -121,9 +117,8 @@ START_TEST(test_verify_name_allowed_default) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("com.example.local.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("example.com", allow_file),
-        VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.com.", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
@@ -158,9 +153,8 @@ START_TEST(test_verify_name_allowed_wildcard) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("com.example.local.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("example.com", allow_file),
-        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.com.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
@@ -170,12 +164,10 @@ START_TEST(test_verify_name_allowed_wildcard) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local.com.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("", allow_file),
-        VERIFY_NAME_RESULT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string(".", allow_file),
-        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
+                     VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
+                     VERIFY_NAME_RESULT_ALLOWED);
 }
 END_TEST
 
@@ -204,8 +196,9 @@ START_TEST(test_verify_name_allowed_too_long) {
         VERIFY_NAME_RESULT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(verify_name_allowed_from_string("example.com.", allow_file),
-                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local.com", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
@@ -233,25 +226,34 @@ START_TEST(test_verify_name_allowed_too_long2) {
         ".local\n";
 
     // The input is truncated at 127 bytes, so we allow this string.
-    ck_assert_int_eq(verify_name_allowed_from_string(
-                         "example"
-                         ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaa",                       // 27 characters
-                         allow_file),
-                     VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string(
+            "example"
+            ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50
+                                                                 // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 50
+                                                                 // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaa", // 27 characters
+            allow_file),
+        VERIFY_NAME_RESULT_ALLOWED);
 
     // Even though this exactly matches the item in the allow file,
     // it is too long.
-    ck_assert_int_eq(verify_name_allowed_from_string(
-                         "example"
-                         ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50 characters
-                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 50 characters
-                         allow_file),
-                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string(
+            "example"
+            ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50
+                                                                  // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50
+                                                                  // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50
+                                                                  // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  // 50
+                                                                  // characters
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 50
+                                                                  // characters
+            allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
 
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local", allow_file),
@@ -267,8 +269,9 @@ START_TEST(test_verify_name_allowed_too_long2) {
         VERIFY_NAME_RESULT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(verify_name_allowed_from_string("example.com.", allow_file),
-                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.com.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local.com", allow_file),
         VERIFY_NAME_RESULT_NOT_ALLOWED);
@@ -284,12 +287,11 @@ END_TEST
 
 // Tests verify_name_allowed with a custom config.
 START_TEST(test_verify_name_allowed_com_and_local) {
-    const char allow_file[] =
-        "# /etc/mdns.allow\n"
-        ".com.\n"
-        ".com\n"
-        ".local.\n"
-        ".local\n";
+    const char allow_file[] = "# /etc/mdns.allow\n"
+                              ".com.\n"
+                              ".com\n"
+                              ".local.\n"
+                              ".local\n";
 
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.local", allow_file),
@@ -303,9 +305,8 @@ START_TEST(test_verify_name_allowed_com_and_local) {
     ck_assert_int_eq(
         verify_name_allowed_from_string("com.example.local.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
-    ck_assert_int_eq(
-        verify_name_allowed_from_string("example.com", allow_file),
-        VERIFY_NAME_RESULT_ALLOWED);
+    ck_assert_int_eq(verify_name_allowed_from_string("example.com", allow_file),
+                     VERIFY_NAME_RESULT_ALLOWED);
     ck_assert_int_eq(
         verify_name_allowed_from_string("example.com.", allow_file),
         VERIFY_NAME_RESULT_ALLOWED);
@@ -317,8 +318,9 @@ START_TEST(test_verify_name_allowed_com_and_local) {
         VERIFY_NAME_RESULT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed_from_string("example.net", allow_file),
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
-    ck_assert_int_eq(verify_name_allowed_from_string("example.net.", allow_file),
-                     VERIFY_NAME_RESULT_NOT_ALLOWED);
+    ck_assert_int_eq(
+        verify_name_allowed_from_string("example.net.", allow_file),
+        VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed_from_string("", allow_file),
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed_from_string(".", allow_file),
@@ -507,11 +509,10 @@ START_TEST(test_buffer_alloc_returns_zeroed_memory) {
 }
 END_TEST
 
-static const uint8_t ipv6_doc_prefix[16] = {0x0, 0x0, 0x0, 0x0,
-                                            0x0, 0x0, 0x0, 0x0,
-                                            0x0, 0x0, 0x0, 0x0,
-                                            0xb8, 0x0d, 0x01, 0x20}; // Documentation prefix
-static const uint32_t ipv4_test_addr = 0xc6336401;                   // 198.51.100.1 (TEST-NET-2)
+static const uint8_t ipv6_doc_prefix[16] = {
+    0x0, 0x0, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,
+    0x0, 0x0, 0x0, 0x0, 0xb8, 0x0d, 0x01, 0x20};   // Documentation prefix
+static const uint32_t ipv4_test_addr = 0xc6336401; // 198.51.100.1 (TEST-NET-2)
 
 static query_address_result_t create_address_result(int offset, int af) {
     query_address_result_t result;
@@ -527,7 +528,8 @@ static query_address_result_t create_address_result(int offset, int af) {
         result.address.ipv4.address = htonl(ipv4_test_addr + offset);
         break;
     case AF_INET6:
-        memcpy(result.address.ipv6.address, ipv6_doc_prefix, sizeof ipv6_doc_prefix);
+        memcpy(result.address.ipv6.address, ipv6_doc_prefix,
+               sizeof ipv6_doc_prefix);
         result.address.ipv6.address[0] = offset;
         result.scopeid = (offset / 2) % 3;
         break;
@@ -549,14 +551,10 @@ static void validate_addrtuples(struct gaih_addrtuple* pat,
         expected_ipv6[0] = i;
         switch (expected_af) {
         case AF_INET:
-            ck_assert_mem_eq(pat->addr,
-                             &expected_ipv4,
-                             sizeof expected_ipv4);
+            ck_assert_mem_eq(pat->addr, &expected_ipv4, sizeof expected_ipv4);
             break;
         case AF_INET6:
-            ck_assert_mem_eq(pat->addr,
-                             expected_ipv6,
-                             sizeof expected_ipv6);
+            ck_assert_mem_eq(pat->addr, expected_ipv6, sizeof expected_ipv6);
             ck_assert_int_eq(pat->scopeid, (i / 2) % 3);
             break;
         }
@@ -579,9 +577,7 @@ static userdata_t create_address_userdata(int num_addresses, int af) {
     return u;
 }
 
-static void poison(char* buf, size_t buflen) {
-    memset(buf, 0x55, buflen);
-}
+static void poison(char* buf, size_t buflen) { memset(buf, 0x55, buflen); }
 
 static void validate_poison(char* buf, size_t buflen, size_t full_buflen) {
     size_t excess = full_buflen - buflen;
@@ -596,7 +592,8 @@ static void validate_hostent(struct hostent* hostent, const char* name, int af,
     ck_assert_ptr_nonnull(hostent->h_aliases);
     ck_assert_ptr_null(hostent->h_aliases[0]);
     ck_assert_int_eq(af, hostent->h_addrtype);
-    ck_assert_int_eq(af == AF_INET ? sizeof(ipv4_address_t) : sizeof(ipv6_address_t),
+    ck_assert_int_eq(af == AF_INET ? sizeof(ipv4_address_t)
+                                   : sizeof(ipv6_address_t),
                      hostent->h_length);
     ck_assert_ptr_nonnull(hostent->h_addr_list);
 
@@ -609,14 +606,10 @@ static void validate_hostent(struct hostent* hostent, const char* name, int af,
         expected_ipv6[0] = i;
         switch (af) {
         case AF_INET:
-            ck_assert_mem_eq(*addr,
-                             &expected_ipv4,
-                             sizeof expected_ipv4);
+            ck_assert_mem_eq(*addr, &expected_ipv4, sizeof expected_ipv4);
             break;
         case AF_INET6:
-            ck_assert_mem_eq(*addr,
-                             expected_ipv6,
-                             sizeof expected_ipv6);
+            ck_assert_mem_eq(*addr, expected_ipv6, sizeof expected_ipv6);
             break;
         }
         addr++;
@@ -636,9 +629,8 @@ START_TEST(test_userdata_to_addrtuple_returns_tuples) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status = convert_userdata_to_addrtuple(&u, "example.local", &pat,
-                                                           &buf,
-                                                           &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_to_addrtuple(
+        &u, "example.local", &pat, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_addrtuples(pat, "example.local", 16);
 }
@@ -653,9 +645,8 @@ START_TEST(test_userdata_to_addrtuple_buffer_too_small_returns_erange) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, 0);
-    enum nss_status status = convert_userdata_to_addrtuple(&u, "example.local", &pat,
-                                                           &buf,
-                                                           &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_to_addrtuple(
+        &u, "example.local", &pat, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(errnop, ERANGE);
     ck_assert_int_eq(h_errnop, NO_RECOVERY);
     ck_assert_int_eq(status, NSS_STATUS_TRYAGAIN);
@@ -677,8 +668,7 @@ START_TEST(test_userdata_to_addrtuple_smallest_buffer_eventually_works) {
         buffer_t buf;
         pat = NULL;
         buffer_init(&buf, buffer, buflen);
-        status = convert_userdata_to_addrtuple(&u, "example.local", &pat,
-                                               &buf,
+        status = convert_userdata_to_addrtuple(&u, "example.local", &pat, &buf,
                                                &errnop, &h_errnop);
         validate_poison(buffer, buflen, sizeof(buffer));
         if (errnop != ERANGE)
@@ -704,9 +694,8 @@ START_TEST(test_userdata_to_addrtuple_nonnull_pat_is_used) {
     memset(&tuple, 0, sizeof tuple);
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status = convert_userdata_to_addrtuple(&u, "example.local", &pat,
-                                                           &buf,
-                                                           &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_to_addrtuple(
+        &u, "example.local", &pat, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_addrtuples(&tuple, "example.local", 16);
 }
@@ -723,11 +712,8 @@ START_TEST(test_userdata_for_name_to_hostent_returns_hostent_4) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status =
-        convert_userdata_for_name_to_hostent(&u, "example.local", AF_INET,
-                                             &result,
-                                             &buf,
-                                             &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_for_name_to_hostent(
+        &u, "example.local", AF_INET, &result, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_hostent(&result, "example.local", AF_INET, 16);
 }
@@ -742,11 +728,8 @@ START_TEST(test_userdata_for_name_to_hostent_returns_hostent_6) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status =
-        convert_userdata_for_name_to_hostent(&u, "example.local", AF_INET6,
-                                             &result,
-                                             &buf,
-                                             &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_for_name_to_hostent(
+        &u, "example.local", AF_INET6, &result, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_hostent(&result, "example.local", AF_INET6, 16);
 }
@@ -761,18 +744,16 @@ START_TEST(test_userdata_for_name_to_hostent_buffer_too_small_returns_erange) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, 0);
-    enum nss_status status =
-        convert_userdata_for_name_to_hostent(&u, "example.local", AF_INET,
-                                             &result,
-                                             &buf,
-                                             &errnop, &h_errnop);
+    enum nss_status status = convert_userdata_for_name_to_hostent(
+        &u, "example.local", AF_INET, &result, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(errnop, ERANGE);
     ck_assert_int_eq(h_errnop, NO_RECOVERY);
     ck_assert_int_eq(status, NSS_STATUS_TRYAGAIN);
 }
 END_TEST
 
-START_TEST(test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4) {
+START_TEST(
+    test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4) {
     userdata_t u = create_address_userdata(16, AF_INET);
     struct hostent result;
     char buffer[2048];
@@ -787,11 +768,8 @@ START_TEST(test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4)
 
         buffer_t buf;
         buffer_init(&buf, buffer, buflen);
-        status =
-            convert_userdata_for_name_to_hostent(&u, "example.local", AF_INET,
-                                                 &result,
-                                                 &buf,
-                                                 &errnop, &h_errnop);
+        status = convert_userdata_for_name_to_hostent(
+            &u, "example.local", AF_INET, &result, &buf, &errnop, &h_errnop);
         validate_poison(buffer, buflen, sizeof(buffer));
         if (errnop != ERANGE)
             break;
@@ -805,7 +783,8 @@ START_TEST(test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4)
 }
 END_TEST
 
-START_TEST(test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_6) {
+START_TEST(
+    test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_6) {
     userdata_t u = create_address_userdata(16, AF_INET6);
     struct hostent result;
     char buffer[2048];
@@ -819,11 +798,8 @@ START_TEST(test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_6)
         errnop = h_errnop = 0;
         buffer_t buf;
         buffer_init(&buf, buffer, buflen);
-        status =
-            convert_userdata_for_name_to_hostent(&u, "example.local", AF_INET6,
-                                                 &result,
-                                                 &buf,
-                                                 &errnop, &h_errnop);
+        status = convert_userdata_for_name_to_hostent(
+            &u, "example.local", AF_INET6, &result, &buf, &errnop, &h_errnop);
         validate_poison(buffer, buflen, sizeof(buffer));
         if (errnop != ERANGE)
             break;
@@ -848,13 +824,9 @@ START_TEST(test_name_and_addr_to_hostent_returns_hostent_4) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status =
-        convert_name_and_addr_to_hostent("example.local", &ipv4,
-                                         sizeof ipv4,
-                                         AF_INET,
-                                         &result,
-                                         &buf,
-                                         &errnop, &h_errnop);
+    enum nss_status status = convert_name_and_addr_to_hostent(
+        "example.local", &ipv4, sizeof ipv4, AF_INET, &result, &buf, &errnop,
+        &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_hostent(&result, "example.local", AF_INET, 1);
 }
@@ -868,13 +840,9 @@ START_TEST(test_name_and_addr_to_hostent_returns_hostent_6) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status =
-        convert_name_and_addr_to_hostent("example.local", &ipv6_doc_prefix,
-                                         sizeof ipv6_doc_prefix,
-                                         AF_INET6,
-                                         &result,
-                                         &buf,
-                                         &errnop, &h_errnop);
+    enum nss_status status = convert_name_and_addr_to_hostent(
+        "example.local", &ipv6_doc_prefix, sizeof ipv6_doc_prefix, AF_INET6,
+        &result, &buf, &errnop, &h_errnop);
     ck_assert_int_eq(status, NSS_STATUS_SUCCESS);
     validate_hostent(&result, "example.local", AF_INET6, 1);
 }
@@ -889,13 +857,9 @@ START_TEST(test_name_and_addr_to_hostent_buffer_too_small_returns_erange) {
 
     buffer_t buf;
     buffer_init(&buf, buffer, sizeof(buffer));
-    enum nss_status status =
-        convert_name_and_addr_to_hostent("example.local", &ipv4,
-                                         sizeof ipv4,
-                                         AF_INET,
-                                         &result,
-                                         &buf,
-                                         &errnop, &h_errnop);
+    enum nss_status status = convert_name_and_addr_to_hostent(
+        "example.local", &ipv4, sizeof ipv4, AF_INET, &result, &buf, &errnop,
+        &h_errnop);
     ck_assert_int_eq(errnop, ERANGE);
     ck_assert_int_eq(h_errnop, NO_RECOVERY);
     ck_assert_int_eq(status, NSS_STATUS_TRYAGAIN);
@@ -915,13 +879,9 @@ START_TEST(test_name_and_addr_to_hostent_smallest_buffer_eventually_works_4) {
         errnop = h_errnop = 0;
         buffer_t buf;
         buffer_init(&buf, buffer, buflen);
-        status =
-            convert_name_and_addr_to_hostent("example.local", &ipv4,
-                                             sizeof ipv4,
-                                             AF_INET,
-                                             &result,
-                                             &buf,
-                                             &errnop, &h_errnop);
+        status = convert_name_and_addr_to_hostent("example.local", &ipv4,
+                                                  sizeof ipv4, AF_INET, &result,
+                                                  &buf, &errnop, &h_errnop);
         validate_poison(buffer, buflen, sizeof(buffer));
         if (errnop != ERANGE)
             break;
@@ -947,13 +907,9 @@ START_TEST(test_name_and_addr_to_hostent_smallest_buffer_eventually_works_6) {
         errnop = h_errnop = 0;
         buffer_t buf;
         buffer_init(&buf, buffer, buflen);
-        status =
-            convert_name_and_addr_to_hostent("example.local", &ipv6_doc_prefix,
-                                             sizeof ipv6_doc_prefix,
-                                             AF_INET6,
-                                             &result,
-                                             &buf,
-                                             &errnop, &h_errnop);
+        status = convert_name_and_addr_to_hostent(
+            "example.local", &ipv6_doc_prefix, sizeof ipv6_doc_prefix, AF_INET6,
+            &result, &buf, &errnop, &h_errnop);
         validate_poison(buffer, buflen, sizeof(buffer));
         if (errnop != ERANGE)
             break;
@@ -1001,7 +957,8 @@ static Suite* util_suite(void) {
     tcase_add_test(tc_buffer, test_zero_buffer_nonzero_alloc_returns_null);
     tcase_add_test(tc_buffer, test_buffer_tiny_alloc_returns_nonnull);
     tcase_add_test(tc_buffer, test_tiny_buffer_tiny_alloc_returns_nonnull);
-    tcase_add_test(tc_buffer, test_tiny_unaligned_buffer_tiny_alloc_returns_null);
+    tcase_add_test(tc_buffer,
+                   test_tiny_unaligned_buffer_tiny_alloc_returns_null);
     tcase_add_test(tc_buffer, test_tiny_buffer_second_alloc_returns_null);
     tcase_add_test(tc_buffer, test_tiny_buffer_one_too_big_alloc_returns_null);
     tcase_add_test(tc_buffer, test_buffer_alloc_returns_zeroed_memory);
@@ -1018,30 +975,38 @@ static Suite* util_suite(void) {
                    test_userdata_to_addrtuple_nonnull_pat_is_used);
     suite_add_tcase(s, tc_userdata_to_addrtuple);
 
-    TCase* tc_userdata_for_name_to_hostent = tcase_create("userdata_for_name_to_hostent");
+    TCase* tc_userdata_for_name_to_hostent =
+        tcase_create("userdata_for_name_to_hostent");
     tcase_add_test(tc_userdata_for_name_to_hostent,
                    test_userdata_for_name_to_hostent_returns_hostent_4);
     tcase_add_test(tc_userdata_for_name_to_hostent,
                    test_userdata_for_name_to_hostent_returns_hostent_6);
-    tcase_add_test(tc_userdata_for_name_to_hostent,
-                   test_userdata_for_name_to_hostent_buffer_too_small_returns_erange);
-    tcase_add_test(tc_userdata_for_name_to_hostent,
-                   test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4);
-    tcase_add_test(tc_userdata_for_name_to_hostent,
-                   test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_6);
+    tcase_add_test(
+        tc_userdata_for_name_to_hostent,
+        test_userdata_for_name_to_hostent_buffer_too_small_returns_erange);
+    tcase_add_test(
+        tc_userdata_for_name_to_hostent,
+        test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_4);
+    tcase_add_test(
+        tc_userdata_for_name_to_hostent,
+        test_userdata_for_name_to_hostent_smallest_buffer_eventually_works_6);
     suite_add_tcase(s, tc_userdata_for_name_to_hostent);
 
-    TCase* tc_name_and_addr_to_hostent = tcase_create("name_and_addr_to_hostent");
+    TCase* tc_name_and_addr_to_hostent =
+        tcase_create("name_and_addr_to_hostent");
     tcase_add_test(tc_name_and_addr_to_hostent,
                    test_name_and_addr_to_hostent_returns_hostent_4);
     tcase_add_test(tc_name_and_addr_to_hostent,
                    test_name_and_addr_to_hostent_returns_hostent_6);
-    tcase_add_test(tc_name_and_addr_to_hostent,
-                   test_name_and_addr_to_hostent_buffer_too_small_returns_erange);
-    tcase_add_test(tc_name_and_addr_to_hostent,
-                   test_name_and_addr_to_hostent_smallest_buffer_eventually_works_4);
-    tcase_add_test(tc_name_and_addr_to_hostent,
-                   test_name_and_addr_to_hostent_smallest_buffer_eventually_works_6);
+    tcase_add_test(
+        tc_name_and_addr_to_hostent,
+        test_name_and_addr_to_hostent_buffer_too_small_returns_erange);
+    tcase_add_test(
+        tc_name_and_addr_to_hostent,
+        test_name_and_addr_to_hostent_smallest_buffer_eventually_works_4);
+    tcase_add_test(
+        tc_name_and_addr_to_hostent,
+        test_name_and_addr_to_hostent_smallest_buffer_eventually_works_6);
     suite_add_tcase(s, tc_name_and_addr_to_hostent);
 
     return s;


### PR DESCRIPTION
Now that some of the complex buffer management code is gone, we
can reasonably reformat the project to 80 columns.