### PR TITLE
Fix -Wformat-truncation problem

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -76,7 +76,7 @@ verify_name_result_t verify_name_allowed(const char* name,
         int valid = 0;
 
         while (!feof(mdns_allow_file)) {
-            char ln[128], ln2[128], *t;
+            char ln[128], ln2[129], *t;
 
             if (!fgets(ln, sizeof(ln), mdns_allow_file))
                 break;


### PR DESCRIPTION
src/util.c:95:52: warning: '__builtin___snprintf_chk' output may be truncated before the last format character [-Wformat-truncation=]
                 snprintf(t = ln2, sizeof(ln2), ".%s", ln);

In file included from /usr/include/stdio.h:861,
                 from src/util.c:28:
/usr/include/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output between 2 and 129 bytes into a destination of size 128
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~