### PR TITLE
FreeBSD/IPv6 improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,11 @@ AM_LDFLAGS=-avoid-version -module -export-dynamic
 if FREEBSD_NSS
 lib_LTLIBRARIES = \
 	nss_mdns.la \
-	nss_mdns_minimal.la
+	nss_mdns4.la \
+	nss_mdns6.la \
+	nss_mdns_minimal.la \
+	nss_mdns4_minimal.la \
+	nss_mdns6_minimal.la
 else
 lib_LTLIBRARIES = \
 	libnss_mdns.la \
@@ -74,6 +78,22 @@ nss_mdns_la_LDFLAGS=$(AM_LDFLAGS) -shrext .so.1
 nss_mdns_minimal_la_SOURCES=$(nss_mdns_la_SOURCES)
 nss_mdns_minimal_la_CFLAGS=$(nss_mdns_la_CFLAGS) -DMDNS_MINIMAL
 nss_mdns_minimal_la_LDFLAGS=$(nss_mdns_la_LDFLAGS)
+
+nss_mdns4_la_SOURCES=$(nss_mdns_la_SOURCES)
+nss_mdns4_la_CFLAGS=$(nss_mdns_la_CFLAGS) -DNSS_IPV4_ONLY=1
+nss_mdns4_la_LDFLAGS=$(nss_mdns_la_LDFLAGS)
+
+nss_mdns4_minimal_la_SOURCES=$(nss_mdns_la_SOURCES)
+nss_mdns4_minimal_la_CFLAGS=$(nss_mdns_la_CFLAGS) -DNSS_IPV4_ONLY=1 -DMDNS_MINIMAL
+nss_mdns4_minimal_la_LDFLAGS=$(nss_mdns_la_LDFLAGS)
+
+nss_mdns6_la_SOURCES=$(nss_mdns_la_SOURCES)
+nss_mdns6_la_CFLAGS=$(nss_mdns_la_CFLAGS) -DNSS_IPV6_ONLY=1
+nss_mdns6_la_LDFLAGS=$(nss_mdns_la_LDFLAGS)
+
+nss_mdns6_minimal_la_SOURCES=$(nss_mdns_la_SOURCES)
+nss_mdns6_minimal_la_CFLAGS=$(nss_mdns_la_CFLAGS) -DNSS_IPV6_ONLY=1 -DMDNS_MINIMAL
+nss_mdns6_minimal_la_LDFLAGS=$(nss_mdns_la_LDFLAGS)
 
 avahi_test_SOURCES = \
 	src/avahi.c src/avahi.h \

--- a/src/bsdnss.c
+++ b/src/bsdnss.c
@@ -45,6 +45,7 @@
 #include "avahi.h"
 #include "config.h"
 #include "util.h"
+#include "nss.h"
 
 #ifdef MDNS_MINIMAL
 /*
@@ -67,49 +68,6 @@
 
 ns_mtab* nss_module_register(const char* source, unsigned int* mtabsize,
                              nss_module_unregister_fn* unreg);
-
-extern enum nss_status _nss_mdns_gethostbyname_r(const char* name,
-                                                 struct hostent* result,
-                                                 char* buffer, size_t buflen,
-                                                 int* errnop, int* h_errnop);
-
-extern enum nss_status _nss_mdns_gethostbyname2_r(const char* name, int af,
-                                                  struct hostent* result,
-                                                  char* buffer, size_t buflen,
-                                                  int* errnop, int* h_errnop);
-extern enum nss_status _nss_mdns_gethostbyaddr_r(struct in_addr* addr, int len,
-                                                 int type,
-                                                 struct hostent* result,
-                                                 char* buffer, size_t buflen,
-                                                 int* errnop, int* h_errnop);
-extern enum nss_status _nss_mdns4_gethostbyname_r(const char* name,
-                                                  struct hostent* result,
-                                                  char* buffer, size_t buflen,
-                                                  int* errnop, int* h_errnop);
-
-extern enum nss_status _nss_mdns4_gethostbyname2_r(const char* name, int af,
-                                                   struct hostent* result,
-                                                   char* buffer, size_t buflen,
-                                                   int* errnop, int* h_errnop);
-extern enum nss_status _nss_mdns4_gethostbyaddr_r(struct in_addr* addr, int len,
-                                                  int type,
-                                                  struct hostent* result,
-                                                  char* buffer, size_t buflen,
-                                                  int* errnop, int* h_errnop);
-extern enum nss_status _nss_mdns6_gethostbyname_r(const char* name,
-                                                  struct hostent* result,
-                                                  char* buffer, size_t buflen,
-                                                  int* errnop, int* h_errnop);
-
-extern enum nss_status _nss_mdns6_gethostbyname2_r(const char* name, int af,
-                                                   struct hostent* result,
-                                                   char* buffer, size_t buflen,
-                                                   int* errnop, int* h_errnop);
-extern enum nss_status _nss_mdns6_gethostbyaddr_r(struct in_addr* addr, int len,
-                                                  int type,
-                                                  struct hostent* result,
-                                                  char* buffer, size_t buflen,
-                                                  int* errnop, int* h_errnop);
 
 typedef enum nss_status (*_bsd_nsstub_fn_t)(const char*, struct hostent*, char*,
                                             size_t, int*, int*);

--- a/src/bsdnss.c
+++ b/src/bsdnss.c
@@ -114,7 +114,6 @@ extern enum nss_status _nss_mdns6_gethostbyaddr_r(struct in_addr* addr, int len,
 typedef enum nss_status (*_bsd_nsstub_fn_t)(const char*, struct hostent*, char*,
                                             size_t, int*, int*);
 
-/* XXX: FreeBSD 5.x is not supported. */
 static NSS_METHOD_PROTOTYPE(__nss_bsdcompat_getaddrinfo);
 static NSS_METHOD_PROTOTYPE(__nss_bsdcompat_gethostbyaddr_r);
 static NSS_METHOD_PROTOTYPE(__nss_bsdcompat_gethostbyname2_r);

--- a/src/nss.c
+++ b/src/nss.c
@@ -33,54 +33,7 @@
 
 #include "avahi.h"
 #include "util.h"
-
-#if defined(NSS_IPV4_ONLY) && !defined(MDNS_MINIMAL)
-#define _nss_mdns_gethostbyname4_r _nss_mdns4_gethostbyname4_r
-#define _nss_mdns_gethostbyname3_r _nss_mdns4_gethostbyname3_r
-#define _nss_mdns_gethostbyname2_r _nss_mdns4_gethostbyname2_r
-#define _nss_mdns_gethostbyname_r _nss_mdns4_gethostbyname_r
-#define _nss_mdns_gethostbyaddr_r _nss_mdns4_gethostbyaddr_r
-#elif defined(NSS_IPV4_ONLY) && defined(MDNS_MINIMAL)
-#define _nss_mdns_gethostbyname4_r _nss_mdns4_minimal_gethostbyname4_r
-#define _nss_mdns_gethostbyname3_r _nss_mdns4_minimal_gethostbyname3_r
-#define _nss_mdns_gethostbyname2_r _nss_mdns4_minimal_gethostbyname2_r
-#define _nss_mdns_gethostbyname_r _nss_mdns4_minimal_gethostbyname_r
-#define _nss_mdns_gethostbyaddr_r _nss_mdns4_minimal_gethostbyaddr_r
-#elif defined(NSS_IPV6_ONLY) && !defined(MDNS_MINIMAL)
-#define _nss_mdns_gethostbyname4_r _nss_mdns6_gethostbyname4_r
-#define _nss_mdns_gethostbyname3_r _nss_mdns6_gethostbyname3_r
-#define _nss_mdns_gethostbyname2_r _nss_mdns6_gethostbyname2_r
-#define _nss_mdns_gethostbyname_r _nss_mdns6_gethostbyname_r
-#define _nss_mdns_gethostbyaddr_r _nss_mdns6_gethostbyaddr_r
-#elif defined(NSS_IPV6_ONLY) && defined(MDNS_MINIMAL)
-#define _nss_mdns_gethostbyname4_r _nss_mdns6_minimal_gethostbyname4_r
-#define _nss_mdns_gethostbyname3_r _nss_mdns6_minimal_gethostbyname3_r
-#define _nss_mdns_gethostbyname2_r _nss_mdns6_minimal_gethostbyname2_r
-#define _nss_mdns_gethostbyname_r _nss_mdns6_minimal_gethostbyname_r
-#define _nss_mdns_gethostbyaddr_r _nss_mdns6_minimal_gethostbyaddr_r
-#elif defined(MDNS_MINIMAL)
-#define _nss_mdns_gethostbyname4_r _nss_mdns_minimal_gethostbyname4_r
-#define _nss_mdns_gethostbyname3_r _nss_mdns_minimal_gethostbyname3_r
-#define _nss_mdns_gethostbyname2_r _nss_mdns_minimal_gethostbyname2_r
-#define _nss_mdns_gethostbyname_r _nss_mdns_minimal_gethostbyname_r
-#define _nss_mdns_gethostbyaddr_r _nss_mdns_minimal_gethostbyaddr_r
-#endif
-
-// Define prototypes for nss function we're going to export (fixes GCC warnings)
-#ifndef __FreeBSD__
-enum nss_status _nss_mdns_gethostbyname4_r(const char*, struct gaih_addrtuple**,
-                                           char*, size_t, int*, int*, int32_t*);
-#endif
-enum nss_status _nss_mdns_gethostbyname3_r(const char*, int, struct hostent*,
-                                           char*, size_t, int*, int*, int32_t*,
-                                           char**);
-enum nss_status _nss_mdns_gethostbyname2_r(const char*, int, struct hostent*,
-                                           char*, size_t, int*, int*);
-enum nss_status _nss_mdns_gethostbyname_r(const char*, struct hostent*, char*,
-                                          size_t, int*, int*);
-enum nss_status _nss_mdns_gethostbyaddr_r(const void*, int, int,
-                                          struct hostent*, char*, size_t, int*,
-                                          int*);
+#include "nss.h"
 
 static avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
                                                     userdata_t* userdata) {

--- a/src/nss.c
+++ b/src/nss.c
@@ -128,9 +128,9 @@ static avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
     }
 }
 
-static enum nss_status gethostbyname_impl(const char* name, int af,
-                                          userdata_t* u, int* errnop,
-                                          int* h_errnop) {
+enum nss_status _nss_mdns_gethostbyname_impl(const char* name, int af,
+                                             userdata_t* u, int* errnop,
+                                             int* h_errnop) {
 
     int name_allowed;
     FILE* mdns_allow_file = NULL;
@@ -207,7 +207,7 @@ enum nss_status _nss_mdns_gethostbyname4_r(const char* name,
     buffer_t buf;
 
     enum nss_status status =
-        gethostbyname_impl(name, AF_UNSPEC, &u, errnop, h_errnop);
+        _nss_mdns_gethostbyname_impl(name, AF_UNSPEC, &u, errnop, h_errnop);
     if (status != NSS_STATUS_SUCCESS) {
         return status;
     }
@@ -238,7 +238,7 @@ enum nss_status _nss_mdns_gethostbyname3_r(const char* name, int af,
 #endif
     }
 
-    enum nss_status status = gethostbyname_impl(name, af, &u, errnop, h_errnop);
+    enum nss_status status = _nss_mdns_gethostbyname_impl(name, af, &u, errnop, h_errnop);
     if (status != NSS_STATUS_SUCCESS) {
         return status;
     }

--- a/src/nss.h
+++ b/src/nss.h
@@ -1,0 +1,52 @@
+#ifndef src_nss_h
+#define src_nss_h
+
+#if defined(NSS_IPV4_ONLY) && !defined(MDNS_MINIMAL)
+#define _nss_mdns_gethostbyname4_r _nss_mdns4_gethostbyname4_r
+#define _nss_mdns_gethostbyname3_r _nss_mdns4_gethostbyname3_r
+#define _nss_mdns_gethostbyname2_r _nss_mdns4_gethostbyname2_r
+#define _nss_mdns_gethostbyname_r _nss_mdns4_gethostbyname_r
+#define _nss_mdns_gethostbyaddr_r _nss_mdns4_gethostbyaddr_r
+#elif defined(NSS_IPV4_ONLY) && defined(MDNS_MINIMAL)
+#define _nss_mdns_gethostbyname4_r _nss_mdns4_minimal_gethostbyname4_r
+#define _nss_mdns_gethostbyname3_r _nss_mdns4_minimal_gethostbyname3_r
+#define _nss_mdns_gethostbyname2_r _nss_mdns4_minimal_gethostbyname2_r
+#define _nss_mdns_gethostbyname_r _nss_mdns4_minimal_gethostbyname_r
+#define _nss_mdns_gethostbyaddr_r _nss_mdns4_minimal_gethostbyaddr_r
+#elif defined(NSS_IPV6_ONLY) && !defined(MDNS_MINIMAL)
+#define _nss_mdns_gethostbyname4_r _nss_mdns6_gethostbyname4_r
+#define _nss_mdns_gethostbyname3_r _nss_mdns6_gethostbyname3_r
+#define _nss_mdns_gethostbyname2_r _nss_mdns6_gethostbyname2_r
+#define _nss_mdns_gethostbyname_r _nss_mdns6_gethostbyname_r
+#define _nss_mdns_gethostbyaddr_r _nss_mdns6_gethostbyaddr_r
+#elif defined(NSS_IPV6_ONLY) && defined(MDNS_MINIMAL)
+#define _nss_mdns_gethostbyname4_r _nss_mdns6_minimal_gethostbyname4_r
+#define _nss_mdns_gethostbyname3_r _nss_mdns6_minimal_gethostbyname3_r
+#define _nss_mdns_gethostbyname2_r _nss_mdns6_minimal_gethostbyname2_r
+#define _nss_mdns_gethostbyname_r _nss_mdns6_minimal_gethostbyname_r
+#define _nss_mdns_gethostbyaddr_r _nss_mdns6_minimal_gethostbyaddr_r
+#elif defined(MDNS_MINIMAL)
+#define _nss_mdns_gethostbyname4_r _nss_mdns_minimal_gethostbyname4_r
+#define _nss_mdns_gethostbyname3_r _nss_mdns_minimal_gethostbyname3_r
+#define _nss_mdns_gethostbyname2_r _nss_mdns_minimal_gethostbyname2_r
+#define _nss_mdns_gethostbyname_r _nss_mdns_minimal_gethostbyname_r
+#define _nss_mdns_gethostbyaddr_r _nss_mdns_minimal_gethostbyaddr_r
+#endif
+
+// Define prototypes for nss function we're going to export (fixes GCC warnings)
+#ifndef __FreeBSD__
+enum nss_status _nss_mdns_gethostbyname4_r(const char*, struct gaih_addrtuple**,
+                                           char*, size_t, int*, int*, int32_t*);
+#endif
+enum nss_status _nss_mdns_gethostbyname3_r(const char*, int, struct hostent*,
+                                           char*, size_t, int*, int*, int32_t*,
+                                           char**);
+enum nss_status _nss_mdns_gethostbyname2_r(const char*, int, struct hostent*,
+                                           char*, size_t, int*, int*);
+enum nss_status _nss_mdns_gethostbyname_r(const char*, struct hostent*, char*,
+                                          size_t, int*, int*);
+enum nss_status _nss_mdns_gethostbyaddr_r(const void*, int, int,
+                                          struct hostent*, char*, size_t, int*,
+                                          int*);
+
+#endif


### PR DESCRIPTION
- Rewrite `__nss_bsdcompat_getaddrinfo` to directly use `gethostbyname_impl` (now named `_nss_mdns_gethostbyname_impl` and non-static)
  - so now `getaddrinfo` with `AF_UNSPEC` would return both v4 and v6 results
  - e.g. on my v6-only avahi setup `curl something.local` with `nss_mdns` eventually returns the expected v6 address
- Reenable `nss_mdns6` and `4` on FreeBSD
  - with `nss_mdns6`, `curl something.local` instantly returns the expected v6 address for me