### PR TITLE
Draft: Change .local domain heuristic

### DIFF
--- a/src/nss.c
+++ b/src/nss.c
@@ -118,7 +118,8 @@ enum nss_status _nss_mdns_gethostbyname_impl(const char* name, int af,
 #ifndef MDNS_MINIMAL
     mdns_allow_file = fopen(MDNS_ALLOW_FILE, "r");
 #endif
-    result = verify_name_allowed_with_soa(name, mdns_allow_file);
+    result = verify_name_allowed_with_soa(name, mdns_allow_file,
+                                          TEST_LOCAL_SOA_AUTO);
 #ifndef MDNS_MINIMAL
     if (mdns_allow_file)
         fclose(mdns_allow_file);

--- a/src/util.c
+++ b/src/util.c
@@ -55,14 +55,17 @@ int ends_with(const char* name, const char* suffix) {
     return strcasecmp(name + ln - ls, suffix) == 0;
 }
 
-use_name_result_t verify_name_allowed_with_soa(const char* name, FILE* mdns_allow_file) {
+use_name_result_t verify_name_allowed_with_soa(const char* name,
+                                               FILE* mdns_allow_file,
+                                               test_local_soa_t test) {
     switch (verify_name_allowed(name, mdns_allow_file)) {
     case VERIFY_NAME_RESULT_NOT_ALLOWED:
         return USE_NAME_RESULT_SKIP;
     case VERIFY_NAME_RESULT_ALLOWED:
         return USE_NAME_RESULT_AUTHORITATIVE;
     case VERIFY_NAME_RESULT_ALLOWED_IF_NO_LOCAL_SOA:
-	if (local_soa())
+	if (test == TEST_LOCAL_SOA_YES ||
+	    (test == TEST_LOCAL_SOA_AUTO && local_soa()) )
 		/* Make multicast resolution not authoritative for .local zone.
 		 * Allow continuing to unicast resolution after multicast had not worked. */
 		return USE_NAME_RESULT_OPTIONAL;

--- a/src/util.h
+++ b/src/util.h
@@ -61,6 +61,12 @@ char* buffer_strdup(buffer_t* buf, const char* str);
 int set_cloexec(int fd);
 int ends_with(const char* name, const char* suffix);
 
+typedef enum {
+    USE_NAME_RESULT_SKIP,
+    USE_NAME_RESULT_AUTHORITATIVE,
+    USE_NAME_RESULT_OPTIONAL,
+} use_name_result_t;
+
 // Returns true if we should try to resolve the name with mDNS.
 //
 // If mdns_allow_file is NULL, then this implements the "local" SOA
@@ -71,7 +77,8 @@ int ends_with(const char* name, const char* suffix);
 //
 // The two heuristics described above are disabled if mdns_allow_file
 // is not NULL.
-int verify_name_allowed_with_soa(const char* name, FILE* mdns_allow_file);
+use_name_result_t verify_name_allowed_with_soa(const char* name,
+                                               FILE* mdns_allow_file);
 
 typedef enum {
     VERIFY_NAME_RESULT_NOT_ALLOWED,

--- a/src/util.h
+++ b/src/util.h
@@ -67,6 +67,12 @@ typedef enum {
     USE_NAME_RESULT_OPTIONAL,
 } use_name_result_t;
 
+typedef enum {
+    TEST_LOCAL_SOA_NO,
+    TEST_LOCAL_SOA_YES,
+    TEST_LOCAL_SOA_AUTO,
+} test_local_soa_t;
+
 // Returns true if we should try to resolve the name with mDNS.
 //
 // If mdns_allow_file is NULL, then this implements the "local" SOA
@@ -78,7 +84,8 @@ typedef enum {
 // The two heuristics described above are disabled if mdns_allow_file
 // is not NULL.
 use_name_result_t verify_name_allowed_with_soa(const char* name,
-                                               FILE* mdns_allow_file);
+                                               FILE* mdns_allow_file,
+                                               test_local_soa_t test);
 
 typedef enum {
     VERIFY_NAME_RESULT_NOT_ALLOWED,

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -50,6 +50,24 @@ START_TEST(test_verify_name_allowed_minimal) {
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
     ck_assert_int_eq(verify_name_allowed(".", NULL),
                      VERIFY_NAME_RESULT_NOT_ALLOWED);
+
+    ck_assert_int_eq(verify_name_allowed_with_soa(".", NULL, TEST_LOCAL_SOA_YES),
+                     USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa(".", NULL, TEST_LOCAL_SOA_NO),
+                     USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa(".", NULL, TEST_LOCAL_SOA_AUTO),
+                     USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa("example3.sub.local",
+                         NULL, TEST_LOCAL_SOA_YES), USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa("example4.sub.local",
+                         NULL, TEST_LOCAL_SOA_NO), USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa("example4.sub.local",
+                         NULL, TEST_LOCAL_SOA_AUTO), USE_NAME_RESULT_SKIP);
+    ck_assert_int_eq(verify_name_allowed_with_soa("example1.local",
+                         NULL, TEST_LOCAL_SOA_YES), USE_NAME_RESULT_OPTIONAL);
+    ck_assert_int_eq(verify_name_allowed_with_soa("example2.local",
+                         NULL, TEST_LOCAL_SOA_NO), USE_NAME_RESULT_AUTHORITATIVE);
+    /* TEST_LOCAL_SOA_AUTO would test actual DNS on host, skip that. */
 }
 END_TEST
 


### PR DESCRIPTION
Previous way skipped all multicast queries when unicast DNS contains local. SOA record. Change that behaviour and always request multicast name. But if local SOA is present, then make missing multicast optional and continue to DNS plugin. That would make names ending with .local to take longer resolve on unicast DNS, but should still deliver the answer.

Attempts to improve issue #75.