### PR TITLE
Pass avahi-daemon parallel IPv4/6 queries

### DIFF
--- a/src/avahi-test.c
+++ b/src/avahi-test.c
@@ -42,6 +42,18 @@ int main(int argc, char* argv[]) {
     else
         printf("AF_UNSPEC: failed (%i).\n", r);
 
+    userdata_t u;
+    u.count = 0;
+    if ((r = do_avahi_resolve_name(AF_UNSPEC, argc >= 2
+                                   ? argv[1] : "cocaine.local", &u)) == 0) {
+        printf("AF_UNSPEC (count): %d\n", u.count);
+        for (int i = 0; i < u.count; i++) {
+            printf("AF_UNSPEC (list): %s\n", inet_ntop(
+                   u.result[i].af, &u.result[i].address, t, sizeof(t)));
+        }
+    } else
+        printf("AF_UNSPEC (list): failed (%i).\n", r);
+
     if ((r = avahi_resolve_address(AF_INET, &(result.address.ipv4), t,
                                    sizeof(t))) == 0)
         printf("REVERSE: %s\n", t);

--- a/src/avahi.h
+++ b/src/avahi.h
@@ -54,6 +54,9 @@ typedef enum {
     AVAHI_RESOLVE_RESULT_UNAVAIL
 } avahi_resolve_result_t;
 
+avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
+                                             userdata_t* userdata);
+
 avahi_resolve_result_t avahi_resolve_name(int af, const char* name,
                                           query_address_result_t* result);
 

--- a/src/nss.c
+++ b/src/nss.c
@@ -36,21 +36,6 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include "util.h"
 #include "nss.h"
 
-static avahi_resolve_result_t do_avahi_resolve_name(int af, const char* name,
-                                                    userdata_t* userdata) {
-    query_address_result_t address_result;
-    switch (avahi_resolve_name(af, name, &address_result)) {
-    case AVAHI_RESOLVE_RESULT_SUCCESS:
-        append_address_to_userdata(&address_result, userdata);
-        return AVAHI_RESOLVE_RESULT_SUCCESS;
-    case AVAHI_RESOLVE_RESULT_HOST_NOT_FOUND:
-        return AVAHI_RESOLVE_RESULT_HOST_NOT_FOUND;
-    default:
-        // Something went wrong, just fail.
-        return AVAHI_RESOLVE_RESULT_UNAVAIL;
-    }
-}
-
 enum nss_status _nss_mdns_gethostbyname_impl(const char* name, int af,
                                              userdata_t* u, int* errnop,
                                              int* h_errnop) {


### PR DESCRIPTION
This optimizes the query time.

[glibc patches are required](https://github.com/avahi/nss-mdns/issues/83#issuecomment-3549952283) to ensure `getent ahosts` uses `_nss_mdns_gethostbyname4_r`. As such, this is untested until the patches land.

Closes: #83