### PR TITLE
avahi: fix missing fflush() in address resolution

### DIFF
--- a/src/avahi.c
+++ b/src/avahi.c
@@ -136,6 +136,7 @@ avahi_resolve_address_with_socket(FILE* f, int af, const void* data, char* name,
     char a[256], ln[256];
 
     fprintf(f, "RESOLVE-ADDRESS %s\n", inet_ntop(af, data, a, sizeof(a)));
+    fflush(f);
 
     if (!(fgets(ln, sizeof(ln), f))) {
         return AVAHI_RESOLVE_RESULT_UNAVAIL;


### PR DESCRIPTION
The function `avahi_resolve_address_with_socket` writes a command to the socket using `fprintf` and immediately attempts to read the response using `fgets`.

Fixes downstream report detected using static analyzers https://bugzilla.redhat.com/show_bug.cgi?id=2362872.