### PR TITLE
Only set IPv6 scope id for link-local addresses

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -29,6 +29,7 @@ SPDX-License-Identifier: LGPL-2.1-or-later
 #include <stdio.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
 
 #include "util.h"
 
@@ -336,6 +337,20 @@ void append_address_to_userdata(const query_address_result_t* result,
     if (u->count >= MAX_ENTRIES)
         return;
 
-    memcpy(&(u->result[u->count]), result, sizeof(*result));
+    query_address_result_t* dst = &u->result[u->count];
+    memcpy(dst, result, sizeof(*dst));
+
+    // The scope id holds the interface index the record was seen on. That is
+    // only meaningful for link-local IPv6 addresses (fe80::/10), which cannot
+    // be used without it. RFC 4007 section 11.1 requires the scope id to be
+    // zero for global-scope addresses; a non-zero scope on a global address is
+    // malformed and breaks consumers such as mount.nfs. Normalize it here, at
+    // the single point where resolved addresses enter userdata, so every
+    // backend (Linux gethostbyname4 and the BSD path) sees a correct value.
+    if (!(dst->af == AF_INET6 &&
+          IN6_IS_ADDR_LINKLOCAL(
+              (const struct in6_addr*)dst->address.ipv6.address)))
+        dst->scopeid = 0;
+
     u->count++;
 }

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -552,8 +552,8 @@ static query_address_result_t create_address_result(int offset, int af) {
     if (af == AF_UNSPEC) {
         // Alternate between IPv4 and IPv6.
         af = offset % 2 ? AF_INET : AF_INET6;
-        result.af = af;
     }
+    result.af = af;
 
     switch (af) {
     case AF_INET:
@@ -588,7 +588,11 @@ static void validate_addrtuples(struct gaih_addrtuple* pat,
             break;
         case AF_INET6:
             ck_assert_mem_eq(pat->addr, expected_ipv6, sizeof expected_ipv6);
-            ck_assert_int_eq(pat->scopeid, (i / 2) % 3);
+            // These are global-scope addresses (documentation prefix), so the
+            // scope id must be cleared regardless of the value Avahi reported.
+            // Link-local scoping is covered by
+            // test_append_address_normalizes_scopeid.
+            ck_assert_int_eq(pat->scopeid, 0);
             break;
         }
 
@@ -610,6 +614,39 @@ static userdata_t create_address_userdata(int num_addresses, int af) {
     }
     return u;
 }
+
+// The scope id (interface index) is only meaningful for link-local IPv6
+// addresses. append_address_to_userdata must preserve it for fe80::/10 and
+// clear it to zero for global-scope addresses, per RFC 4007 section 11.1.
+START_TEST(test_append_address_normalizes_scopeid) {
+    static const uint8_t linklocal[16] = {0xfe, 0x80, 0, 0, 0, 0, 0, 0,
+                                          0,    0,    0, 0, 0, 0, 0, 0x01};
+    static const uint8_t global[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+                                       0,    0,    0,    0,    0, 0, 0, 0x01};
+
+    userdata_t u;
+    u.count = 0;
+
+    query_address_result_t ll = {.af = AF_INET6, .scopeid = 3};
+    memcpy(ll.address.ipv6.address, linklocal, sizeof linklocal);
+    append_address_to_userdata(&ll, &u);
+
+    query_address_result_t gl = {.af = AF_INET6, .scopeid = 3};
+    memcpy(gl.address.ipv6.address, global, sizeof global);
+    append_address_to_userdata(&gl, &u);
+
+    ck_assert_int_eq(u.count, 2);
+
+    // Link-local address: scope id preserved.
+    ck_assert_int_eq(u.result[0].scopeid, 3);
+    ck_assert_mem_eq(u.result[0].address.ipv6.address, linklocal,
+                     sizeof linklocal);
+
+    // Global address: scope id cleared.
+    ck_assert_int_eq(u.result[1].scopeid, 0);
+    ck_assert_mem_eq(u.result[1].address.ipv6.address, global, sizeof global);
+}
+END_TEST
 
 static void poison(char* buf, size_t buflen) { memset(buf, 0x55, buflen); }
 
@@ -1012,6 +1049,10 @@ static Suite* util_suite(void) {
                    test_userdata_to_addrtuple_nonnull_pat_is_used);
     suite_add_tcase(s, tc_userdata_to_addrtuple);
 #endif
+
+    TCase* tc_append_address = tcase_create("append_address");
+    tcase_add_test(tc_append_address, test_append_address_normalizes_scopeid);
+    suite_add_tcase(s, tc_append_address);
 
     TCase* tc_userdata_for_name_to_hostent =
         tcase_create("userdata_for_name_to_hostent");


### PR DESCRIPTION
## Problem

When resolving an IPv6 `.local` name, nss-mdns copies the interface index Avahi reports into `sin6_scope_id` for every returned address. That is correct and necessary for link-local addresses (`fe80::/10`), which cannot be used without a zone index. But RFC 4007 Sec 11.1 requires the scope id to be 0 for global-scope (and ULA) addresses.

A non-zero scope id on a global address produces a malformed address like `2001:db8::1%3`. This breaks downstream consumers such as `mount.nfs` (see Debian #898527).

## Fix

In `convert_userdata_to_addrtuple()`, gate the scope id assignment on `IN6_IS_ADDR_LINKLOCAL` and explicitly clear it to zero otherwise:

```c
if (result->af == AF_INET6 &&
    IN6_IS_ADDR_LINKLOCAL(
        (const struct in6_addr*)result->address.ipv6.address))
    tuple->scopeid = result->scopeid;
else
    tuple->scopeid = 0;
```

Link-local resolution is unchanged the scope id is still emitted for `fe80::/10`, just not for global addresses. This matches what `systemd-resolved` already does (it only scopes link-local results).

## Tests

Added `test_userdata_to_addrtuple_scopeid` covering both cases: a link-local address keeps its scope id, a global address has it zeroed. Also updated the existing `validate_addrtuples` assertion, since its fixtures use the global documentation prefix and therefore must now have a zero scope id. `make check` passes; reverting the fix makes the new test fail as expected.

Fixes #69
Refs Debian #898527 (https://bugs.debian.org/898527)